### PR TITLE
Don't accept stalemate as a win in "Mate in N" practices

### DIFF
--- a/Code/GestorMate.py
+++ b/Code/GestorMate.py
@@ -443,13 +443,15 @@ class GestorMate(Gestor.Gestor):
         if not jg:
             return False
 
-        self.partida.ultPosicion = jg.posicion
         self.partida.append_jg(jg)
         if self.siAyuda:
             self.tablero.quitaFlechas()
         self.movimientosPiezas(jg.liMovs, False)
-        if self.siTerminada():
-            self.siguienteMate()
+        if self.partida.siTerminada():
+            if jg.siJaqueMate:
+                self.siguienteMate()
+            else:
+                self.repiteMate(True, True)
             return
 
         self.numMov += 1
@@ -464,7 +466,6 @@ class GestorMate(Gestor.Gestor):
         coronacion = rm.coronacion
 
         siBien, mens, jg = Jugada.dameJugada(self.partida.ultPosicion, desde, hasta, coronacion)
-        self.partida.ultPosicion = jg.posicion
         self.partida.append_jg(jg)
         self.ponFlechaSC(jg.desde, jg.hasta)
         self.movimientosPiezas(jg.liMovs, False)


### PR DESCRIPTION
Both stable and development versions of Lucas Chess accept a stalemate as a win in "Mate in N" practices.

**Reproduction of bug**

1. Select Train -> Training mates -> Mate in 3
2. Start a practicing session on Level 1 Block 8
3. Win the first puzzle by e.g. 1. Ra1 Rd7 2. Rxd7 f2 3. Ra8#
4. Achieve a stalemate by e.g. 1. Qf8 Kg6 2. Rd7

**Attempted solution**

I added a test for checkmate before proceeding to the next puzzle in the case of no legal moves for the machine. (I also removed two unnecessary assignments in the same function, not altering the software's behavior.)